### PR TITLE
[GAF-32] added support for multilangual search

### DIFF
--- a/src/main/java/org/lekitech/gafalag/controller/ExpressionController.java
+++ b/src/main/java/org/lekitech/gafalag/controller/ExpressionController.java
@@ -48,20 +48,26 @@ public class ExpressionController {
 
     @Transactional
     @GetMapping(path = "/search")
-    public List<ExpressionResponse> search(@RequestParam String exp) {
-        return expressionService.fuzzySearch(exp).stream().map(expressionMapper::toDto).toList();
+    public List<ExpressionResponse> search(@RequestParam String exp,
+                                           @RequestParam String fromLang,
+                                           @RequestParam String toLang) {
+        return expressionService.fuzzySearch(exp, fromLang, toLang).stream().map(expressionMapper::toDto).toList();
     }
 
     @Transactional
     @GetMapping(path = "/search/suggestions")
-    public List<String> searchSuggestions(@RequestParam String exp) {
-        return expressionService.fuzzySearch(exp).stream().map(Expression::getSpelling).toList();
+    public List<String> searchSuggestions(@RequestParam String exp,
+                                          @RequestParam String fromLang,
+                                          @RequestParam String toLang) {
+        return expressionService.fuzzySearch(exp, fromLang, toLang).stream().map(Expression::getSpelling).toList();
     }
 
     @Transactional
     @GetMapping(path = "/search/definition")
-    public List<ExpressionResponse> searchByDefinition(@RequestParam String text) {
-        return expressionService.fullTextSearch(text).stream().map(expressionMapper::toDto).toList();
+    public List<ExpressionResponse> searchByDefinition(@RequestParam String text,
+                                                       @RequestParam String fromLang,
+                                                       @RequestParam String toLang) {
+        return expressionService.fullTextSearch(text, fromLang, toLang).stream().map(expressionMapper::toDto).toList();
     }
 
     @GetMapping(path = "")

--- a/src/main/java/org/lekitech/gafalag/repository/ExpressionRepository.java
+++ b/src/main/java/org/lekitech/gafalag/repository/ExpressionRepository.java
@@ -18,16 +18,26 @@ public interface ExpressionRepository extends JpaRepository<Expression, UUID> {
 
     Page<Expression> findAllByLanguageId(String languageId, Pageable pageable);
 
+    // TODO: find way to filter on "toLang" from database
+//                    "JOIN definition d ON e.id = d.expression_id " +
+    // AND d.language_id = :toLang " +
+
     @Query(nativeQuery = true,
-            value = "SELECT * FROM expression " +
+            value = "SELECT * FROM expression e " +
+                    "WHERE e.language_id = :fromLang " +
                     "ORDER BY spelling <-> :exp " +
                     "LIMIT 10")
-    List<Expression> fuzzySearch(@Param("exp") String exp);
+    List<Expression> fuzzySearch(@Param("exp") String exp,
+                                 @Param("fromLang") String fromLang);
+//                                 @Param("toLang") String toLang);
 
     @Query(nativeQuery = true,
             value = "SELECT * FROM expression e " +
                     "JOIN definition d ON e.id = d.expression_id " +
-                    "WHERE to_tsvector(d.definition_text) @@ to_tsquery(:text) " +
+                    "WHERE e.language_id = :toLang AND d.language_id = :fromLang " +
+                        "AND to_tsvector(d.definition_text) @@ to_tsquery(:text) " +
                     "LIMIT 10")
-    List<Expression> fullTextSearch(@Param("text") String text);
+    List<Expression> fullTextSearch(@Param("text") String text,
+                                    @Param("fromLang") String fromLang,
+                                    @Param("toLang") String toLang);
 }

--- a/src/main/java/org/lekitech/gafalag/repository/ExpressionRepository.java
+++ b/src/main/java/org/lekitech/gafalag/repository/ExpressionRepository.java
@@ -18,10 +18,12 @@ public interface ExpressionRepository extends JpaRepository<Expression, UUID> {
 
     Page<Expression> findAllByLanguageId(String languageId, Pageable pageable);
 
-    // TODO: find way to filter on "toLang" from database
-//                    "JOIN definition d ON e.id = d.expression_id " +
-    // AND d.language_id = :toLang " +
-
+    // TODO: find way to filter on "toLang" from database query to replace current implementation in ExpressionService
+    //       We need tis filter for the cases when we have multiple translations form single language e.g.:
+    //          - Russian -> Lezgi
+    //          - Russian -> Tabasaran
+    //       In this case user should only get translations from Russian to the selected language and
+    //       not all available languages
     @Query(nativeQuery = true,
             value = "SELECT * FROM expression e " +
                     "WHERE e.language_id = :fromLang " +
@@ -29,7 +31,6 @@ public interface ExpressionRepository extends JpaRepository<Expression, UUID> {
                     "LIMIT 10")
     List<Expression> fuzzySearch(@Param("exp") String exp,
                                  @Param("fromLang") String fromLang);
-//                                 @Param("toLang") String toLang);
 
     @Query(nativeQuery = true,
             value = "SELECT * FROM expression e " +

--- a/src/main/java/org/lekitech/gafalag/service/ExpressionService.java
+++ b/src/main/java/org/lekitech/gafalag/service/ExpressionService.java
@@ -10,6 +10,7 @@ import org.lekitech.gafalag.repository.ExpressionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -92,11 +93,18 @@ public class ExpressionService {
         );
     }
 
-    public List<Expression> fuzzySearch(String exp) {
-        return repository.fuzzySearch(exp);
+    public List<Expression> fuzzySearch(String exp, String fromLang, String toLang) {
+        var result = repository.fuzzySearch(exp, fromLang);
+        for(var expression : result) {
+            var filteredDefinitions = expression.getDefinitions().stream()
+                    .filter(def -> def.getLanguage().getId().equals(toLang))
+                    .toList();
+            expression.setDefinitions(filteredDefinitions);
+        }
+        return result;
     }
 
-    public List<Expression> fullTextSearch(String text) {
-        return repository.fullTextSearch(text);
+    public List<Expression> fullTextSearch(String text, String fromLang, String toLang) {
+        return repository.fullTextSearch(text, fromLang, toLang);
     }
 }


### PR DESCRIPTION
Дополнил методы `fuzzySearch` и `fullTextSearch` репозитория `Expression` для поиска слов и их значений по конкретным языкам. Аргумент `fromLang` указывает на язык на котором ведется поиск слова а `toLang` указывает на язык в котором ищут перевод