### PR TITLE
minor fixes regarding variables naming and suggestions db query

### DIFF
--- a/src/main/java/org/lekitech/gafalag/controller/v2/ExpressionControllerV2.java
+++ b/src/main/java/org/lekitech/gafalag/controller/v2/ExpressionControllerV2.java
@@ -42,9 +42,10 @@ public class ExpressionControllerV2 {
     public ResponseEntity<List<String>> searchSuggestions(
             @RequestParam(name = "spelling") String spelling,
             @RequestParam(name = "expLang") String expLang,
+            @RequestParam(name = "defLang") String defLang,
             @RequestParam(name = "size") Long size) {
         try {
-            final List<String> suggestions = expService.searchSuggestions(spelling, expLang, size);
+            final List<String> suggestions = expService.searchSuggestions(spelling, expLang, defLang, size);
             return ResponseEntity.ok(suggestions);
         } catch (Exception e) {
             log.error("Error occurred while retrieving search suggestions: {}", e.getMessage(), e);

--- a/src/main/java/org/lekitech/gafalag/service/v2/ExpressionServiceV2.java
+++ b/src/main/java/org/lekitech/gafalag/service/v2/ExpressionServiceV2.java
@@ -38,46 +38,11 @@ public class ExpressionServiceV2 {
      * and pageable information.
      *
      * @param spelling The expression to search for.
-     * @param srcLang  The source language for the expression.
+     * @param expLang  The source language for the expression.
      * @param size     The limit of the suggestions.
      * @return A List of strings containing search suggestions.
      */
-    public List<String> searchSuggestions(String spelling, String srcLang, Long size) {
-        return expressionRepo.fuzzySearchSpellingsListBySpellingAndSrcLang(spelling, srcLang, size);
-    }
-
-    /**
-     * Finds expressions by spelling, source language, and destination language with fuzzy matching,
-     * and returns a Page of ExpressionResponseDto objects.
-     *
-     * @param spelling The spelling of the expression to search for.
-     * @param srcLang  The source language for the expression.
-     * @param distLang The destination language for the expression details.
-     * @param pageable The pageable information for the search results.
-     * @return A Page of ExpressionResponseDto objects containing expression details.
-     */
-    @Deprecated
-    @Transactional(readOnly = true)
-    public Page<ExpressionResponseDto> findExpressionsBySpellingAndSrcLang(String spelling,
-                                                                           String srcLang,
-                                                                           String distLang,
-                                                                           Pageable pageable) {
-        final Page<Expression> entities = expressionRepo
-                .fuzzySearchSExpressionsListBySpellingAndSrcLang(spelling, srcLang, pageable);
-
-        final List<ExpressionResponseDto> dtos = entities.stream().map(expression -> {
-            final List<ExpressionDetails> expressionDetails = expression.getExpressionDetails().stream()
-                    .map(expDetail -> {
-                        val filteredDefinitionDetailsByDistLang = expDetail.getDefinitionDetails()
-                                .stream().filter(
-                                        defDetail -> defDetail.getLanguage().getId().equals(distLang)
-                                ).toList();
-                        expDetail.setDefinitionDetails(filteredDefinitionDetailsByDistLang);
-                        return expDetail;
-                    }).toList();
-            return mapper.toDto(expression.getSpelling(), expressionDetails);
-        }).toList();
-
-        return new PageImpl<>(dtos, pageable, entities.getTotalElements());
+    public List<String> searchSuggestions(String spelling, String expLang, String defLang, Long size) {
+        return expressionRepo.fuzzySearchSpellingsListBySpellingAndExpLang(spelling, expLang, defLang, size);
     }
 }


### PR DESCRIPTION
- removed unused service and repository methods for fetching paginated fuzzy search results
- added `defLang` to suggestions query
- renamed all `srcLang` to `expLang` according to the database columns naming